### PR TITLE
Fix due posts time filter

### DIFF
--- a/scheduled_posts.py
+++ b/scheduled_posts.py
@@ -88,9 +88,10 @@ def format_post_preview(post: dict, user: dict = None) -> str:
     if post.get('channels'):
         text += f"📺 **Канал:** {post['channels']['name']}\n"
     
-    # Формат
-    if post.get('parse_mode'):
-        text += f"🎨 **Формат:** {post['parse_mode']}\n"
+    # Формат текста
+    fmt = post.get('format') or post.get('parse_mode')
+    if fmt:
+        text += f"🎨 **Формат:** {fmt}\n"
     
     text += "\n" + "─" * 30 + "\n\n"
     


### PR DESCRIPTION
## Summary
- handle timezone correctly when querying due posts
- fix format display in scheduled post previews

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_683f8685cd388323888537b49c41df31