### PR TITLE
Handle unmatched formatting tags

### DIFF
--- a/auto_post_fixed.py
+++ b/auto_post_fixed.py
@@ -5,6 +5,7 @@ from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 import supabase_db
 from __init__ import TEXTS
 import json
+from view_post import clean_text_for_format
 
 def prepare_media_text(text: str, max_caption_length: int = 1000) -> tuple[str, str]:
     """
@@ -92,15 +93,20 @@ async def start_scheduler(bot: Bot, check_interval: int = 2):
                 # Determine parse mode
                 parse_mode = None
                 if parse_mode_field and parse_mode_field.lower() == "markdown":
-                    parse_mode = "Markdown"
+                    parse_mode = "MarkdownV2"
                 elif parse_mode_field and parse_mode_field.lower() == "html":
                     parse_mode = "HTML"
-                
+
+                cleaned_text = clean_text_for_format(
+                    text,
+                    parse_mode.replace("V2", "") if parse_mode else None,
+                )
+
                 # Try to publish
                 try:
                     if media_id and media_type:
                         # Подготавливаем текст для медиа с caption (ИСПРАВЛЕНО - уменьшен лимит)
-                        caption_text, additional_text = prepare_media_text(text, max_caption_length=1000)
+                        caption_text, additional_text = prepare_media_text(cleaned_text, max_caption_length=1000)
                         
                         if media_type.lower() == "photo":
                             await bot.send_photo(
@@ -137,9 +143,9 @@ async def start_scheduler(bot: Bot, check_interval: int = 2):
                     else:
                         # Для текстовых сообщений без медиа ограничений caption нет
                         await bot.send_message(
-                            chat_id, 
-                            text or TEXTS['ru']['no_text'], 
-                            parse_mode=parse_mode, 
+                            chat_id,
+                            cleaned_text or TEXTS['ru']['no_text'],
+                            parse_mode=parse_mode,
                             reply_markup=markup
                         )
                     
@@ -154,7 +160,7 @@ async def start_scheduler(bot: Bot, check_interval: int = 2):
                         try:
                             print(f"🔄 Повторная попытка с коротким caption для поста #{post_id}")
                             # Еще более короткий caption
-                            caption_text, additional_text = prepare_media_text(text, max_caption_length=500)
+                            caption_text, additional_text = prepare_media_text(cleaned_text, max_caption_length=500)
                             
                             if media_type.lower() == "photo":
                                 await bot.send_photo(chat_id, photo=media_id, caption=caption_text, parse_mode=parse_mode, reply_markup=markup)

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.types import CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.fsm.context import FSMContext
 from dotenv import load_dotenv
+from view_post import clean_text_for_format
 
 # Load environment variables
 load_dotenv()
@@ -88,10 +89,15 @@ async def publish_post_immediately(bot: Bot, post_id: int) -> bool:
         # Determine parse mode
         parse_mode = None
         if parse_mode_field and parse_mode_field.lower() == "markdown":
-            parse_mode = "Markdown"
+            parse_mode = "MarkdownV2"
         elif parse_mode_field and parse_mode_field.lower() == "html":
             parse_mode = "HTML"
-        
+
+        cleaned_text = clean_text_for_format(
+            text,
+            parse_mode.replace("V2", "") if parse_mode else None,
+        )
+
         # Функция для подготовки текста с обрезкой caption
         def prepare_media_text(text: str, max_caption_length: int = 1000) -> tuple[str, str]:
             if not text:
@@ -114,7 +120,7 @@ async def publish_post_immediately(bot: Bot, post_id: int) -> bool:
         
         # Публикуем пост
         if media_id and media_type:
-            caption_text, additional_text = prepare_media_text(text)
+            caption_text, additional_text = prepare_media_text(cleaned_text)
             
             if media_type.lower() == "photo":
                 await bot.send_photo(
@@ -149,9 +155,9 @@ async def publish_post_immediately(bot: Bot, post_id: int) -> bool:
                 )
         else:
             await bot.send_message(
-                chat_id, 
-                text or "Пост без текста", 
-                parse_mode=parse_mode, 
+                chat_id,
+                cleaned_text or "Пост без текста",
+                parse_mode=parse_mode,
                 reply_markup=markup
             )
         

--- a/view_post.py
+++ b/view_post.py
@@ -76,52 +76,58 @@ def clean_text_for_format(text: str, parse_mode: str) -> str:
     
     elif parse_mode == "Markdown":
         # Сначала экранируем все специальные символы Markdown
-        # Список символов, которые нужно экранировать в MarkdownV2
         special_chars = ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!', '\\']
-        
-        # Временно заменяем наши теги на плейсхолдеры
+
+        # Обрабатываем ссылки [url=link]text[/url] заранее
         placeholders = {}
-        placeholder_count = 0
-        
-        # Сохраняем наши теги
-        our_tags = [
-            ('[b]', '[/b]', '__BOLD_START__', '__BOLD_END__'),
-            ('[i]', '[/i]', '__ITALIC_START__', '__ITALIC_END__'),
-            ('[u]', '[/u]', '__UNDERLINE_START__', '__UNDERLINE_END__'),
-            ('[s]', '[/s]', '__STRIKE_START__', '__STRIKE_END__'),
-            ('[code]', '[/code]', '__CODE_START__', '__CODE_END__'),
-            ('[pre]', '[/pre]', '__PRE_START__', '__PRE_END__')
-        ]
-        
-        # Заменяем наши теги на плейсхолдеры
-        for start_tag, end_tag, start_placeholder, end_placeholder in our_tags:
-            text = text.replace(start_tag, start_placeholder)
-            text = text.replace(end_tag, end_placeholder)
-        
-        # Обрабатываем ссылки отдельно
         url_pattern = r'\[url=([^\]]+)\]([^\[]+)\[/url\]'
-        urls = re.findall(url_pattern, text)
-        for i, (url, link_text) in enumerate(urls):
-            placeholder = f'__URL_PLACEHOLDER_{i}__'
-            placeholders[placeholder] = f'[{link_text}]({url})'
+        for i, (url, link_text) in enumerate(re.findall(url_pattern, text)):
+            placeholder = f'URLPH{i}'
+
+            # Экранируем спецсимволы внутри ссылочного текста
+            escaped_link_text = link_text
+            for char in special_chars:
+                escaped_link_text = escaped_link_text.replace(char, '\\' + char)
+
+            # Экранируем problem characters в URL ("(" и ")")
+            escaped_url = url.replace(')', '\\)').replace('(', '\\(').replace('\\', '\\\\')
+
+            placeholders[placeholder] = f'[{escaped_link_text}]({escaped_url})'
             text = re.sub(r'\[url=' + re.escape(url) + r'\]' + re.escape(link_text) + r'\[/url\]', placeholder, text, count=1)
-        
+
+        # Наши пользовательские теги, обрабатываем только парные вхождения
+        tag_defs = [
+            ('[b]', '[/b]', 'PHBOLDSTART', 'PHBOLDEND', '*'),
+            ('[i]', '[/i]', 'PHITALICSTART', 'PHITALICEND', '_'),
+            ('[u]', '[/u]', 'PHUNDERLINESTART', 'PHUNDERLINEEND', '__'),
+            ('[s]', '[/s]', 'PHSTRIKESTART', 'PHSTRIKEEND', '~'),
+            ('[code]', '[/code]', 'PHCODESTART', 'PHCODEEND', '`'),
+            ('[pre]', '[/pre]', 'PHPRESTART', 'PHPREEND', '```')
+        ]
+
+        for start_tag, end_tag, start_ph, end_ph, md in tag_defs:
+            pattern = re.escape(start_tag) + r'(.*?)' + re.escape(end_tag)
+            text = re.sub(pattern, lambda m: f'{start_ph}{m.group(1)}{end_ph}', text, flags=re.DOTALL)
+
         # Экранируем специальные символы
         for char in special_chars:
             text = text.replace(char, '\\' + char)
-        
-        # Возвращаем наши теги как Markdown
-        text = text.replace('__BOLD_START__', '*').replace('__BOLD_END__', '*')
-        text = text.replace('__ITALIC_START__', '_').replace('__ITALIC_END__', '_')
-        text = text.replace('__UNDERLINE_START__', '__').replace('__UNDERLINE_END__', '__')
-        text = text.replace('__STRIKE_START__', '~').replace('__STRIKE_END__', '~')
-        text = text.replace('__CODE_START__', '`').replace('__CODE_END__', '`')
-        text = text.replace('__PRE_START__', '```').replace('__PRE_END__', '```')
-        
+
+        # Возвращаем теги как Markdown
+        for start_ph, end_ph, md in [
+            ('PHBOLDSTART', 'PHBOLDEND', '*'),
+            ('PHITALICSTART', 'PHITALICEND', '_'),
+            ('PHUNDERLINESTART', 'PHUNDERLINEEND', '__'),
+            ('PHSTRIKESTART', 'PHSTRIKEEND', '~'),
+            ('PHCODESTART', 'PHCODEEND', '`'),
+            ('PHPRESTART', 'PHPREEND', '```'),
+        ]:
+            text = text.replace(start_ph, md).replace(end_ph, md)
+
         # Возвращаем ссылки
         for placeholder, markdown_link in placeholders.items():
             text = text.replace(placeholder, markdown_link)
-        
+
         return text
     
     else:


### PR DESCRIPTION
## Summary
- Only convert custom [b]/[i]/… tags when both start and end tags are present, leaving unmatched markers untouched
- Support same balanced-tag logic in scheduled post formatter and convert custom tags to HTML
- Sanitize text before sending posts, escaping MarkdownV2 formatting in immediate and scheduled publishing
- Escape special characters in link text and parentheses in URLs to prevent Telegram Markdown parse errors

## Testing
- `python -m py_compile main.py auto_post_fixed.py view_post.py scheduled_posts.py`


------
https://chatgpt.com/codex/tasks/task_b_688ce1ac9dac832db734eb8d64be4c0d